### PR TITLE
Updated Russian translations

### DIFF
--- a/ru/GLOSSARY.md
+++ b/ru/GLOSSARY.md
@@ -21,15 +21,15 @@ Class names and proper nouns do not get translated.
 - pipe operator - оператор потока
 - sigils - строковая метка
 - tuple - кортеж
-- function clauses - функциональное ветвление (???)
+- function clauses - объявления функций
 
 #### CS terms
 
 - boolean - логический тип
 - concatenation - конкатенация
 - exception - исключение
-- float - число с плавающей точкой
-- head - голова
+- float - число с плавающей запятой
+- head - глава
 - integer - целое число
 - interpolation - интерполяция
 - map - ассоциативный массив

--- a/ru/GLOSSARY.md
+++ b/ru/GLOSSARY.md
@@ -29,7 +29,7 @@ Class names and proper nouns do not get translated.
 - concatenation - конкатенация
 - exception - исключение
 - float - число с плавающей запятой
-- head - глава
+- head - голова
 - integer - целое число
 - interpolation - интерполяция
 - map - ассоциативный массив


### PR DESCRIPTION
head - глава, как в "во главе ряда".
float - число с плавающей запятой. В русской записи дробная часть отбивается запятой.

function clauses - объявления функций. Clause - слишком базовое понятие, чтобы его перевести прямо. Но по сути описывается факт наличия у функции множества вариантов, которые применяются по необходимости. В русском языке для этого исторически используется "объявление" или "определение". С первого взгляда "определение" подходит лучше, ведь тело функции тоже присутствует. Но как раз тело функции при сравнении с образцом не рассматривается. Так что "объявление" лучше указывает на суть термина.
